### PR TITLE
Added function to remove duplicate preprints.

### DIFF
--- a/crawl.R
+++ b/crawl.R
@@ -74,6 +74,9 @@ out <- rbind(out[politics_flag, ],
         out[!politics_flag & !economics_flag & !sociology_flag & unspecified_flag, ], 
         out[!politics_flag & !economics_flag & !sociology_flag & !unspecified_flag, ])
 
+# Remove duplicates
+out <- remove_duplicates(out)
+
 # Output JSON
 out_json <- render_json(out, date=as.Date(now)) 
 write(out_json, paste0("./output/osf.json"))

--- a/fun.R
+++ b/fun.R
@@ -78,6 +78,19 @@ flag_in_list <- function(lst, flag){
     unlist(lapply(lst, function(x) sum(x %in% flag)>0 ))
     }
 
+# Remove duplicates
+remove_duplicates <- function(df="out") {
+    df$version <- as.numeric(gsub(".*v", "", df$doi))
+    
+    # subjects is not needed but it's a list-column and causes issues with ordering
+    group_cols <- setdiff(names(df), c("doi", "url", "created", "subjects", "version"))
+    
+    df_ordered <- df[do.call(order, c(df[group_cols], list(-df$version))), ]
+    df_filtered <- df_ordered[!duplicated(df_ordered[group_cols]), ]
+    df_filtered <- df_filtered[, !names(df_filtered) %in% "version"]
+
+    return(df_filtered)
+}
 
 # Crossref 
 


### PR DESCRIPTION
Duplicates occur when two versions of the same preprint were released in the same week. In this case, values from all columns are duplicated except the `url` and the `doi` which are kept unique via the inclusion of the version number at the end of each – for instance: https://osf.io/preprints/socarxiv/2rctz_v1 is the first version of the preprint. 

To prevent such duplicates, we create a numeric variable `version` and use it to keep only the most recent version of each article, by taking the maximum value of the variable. Using the variable `created` would spare the creation of a new variable, but would cause issues when two versions of an article are posted on the same day. 

We use base R for consistency with the rest of the codebase. 

**Absolutely no need to merge if having the two versions included in the user interface is useful**, although in which case it might be worth adding an entry for the version number in the UI. 